### PR TITLE
Added placeholder image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -37,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image?item.image:placeholder}
+        src={item.image ? item.image : placeholder}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import agent from "../agent";
 import { connect } from "react-redux";
 import { ITEM_FAVORITED, ITEM_UNFAVORITED } from "../constants/actionTypes";
+import placeholder from "../../public/placeholder.png";
 
 const mapDispatchToProps = (dispatch) => ({
   favorite: (slug) =>
@@ -36,7 +37,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image?item.image:placeholder}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
Added Placeholder Image for Items on display. It will now display a placeholder instead of a broken image.

![fix](https://user-images.githubusercontent.com/56683962/200113309-3f9bb14c-c8d4-4a55-879a-58e9604b66bd.png)
